### PR TITLE
Fix some not-always-turned-on compiler warnings

### DIFF
--- a/code/scrypt-jane-chacha.h
+++ b/code/scrypt-jane-chacha.h
@@ -52,7 +52,7 @@ typedef uint32_t scrypt_mix_word_t;
 
 #if !defined(SCRYPT_CHOOSE_COMPILETIME)
 static scrypt_ROMixfn
-scrypt_getROMix() {
+scrypt_getROMix(void) {
 	size_t cpuflags = detect_cpu();
 
 #if defined(SCRYPT_CHACHA_AVX)
@@ -80,7 +80,7 @@ scrypt_getROMix() {
 
 #if defined(SCRYPT_TEST_SPEED)
 static size_t
-available_implementations() {
+available_implementations(void) {
 	size_t cpuflags = detect_cpu();
 	size_t flags = 0;
 
@@ -104,7 +104,7 @@ available_implementations() {
 #endif
 
 static int
-scrypt_test_mix() {
+scrypt_test_mix(void) {
 	static const uint8_t expected[16] = {
 		0x48,0x2b,0x2d,0xb8,0xa1,0x33,0x22,0x73,0xcd,0x16,0xc4,0xb4,0xb0,0x7f,0xb1,0x8a,
 	};

--- a/code/scrypt-jane-hash.h
+++ b/code/scrypt-jane-hash.h
@@ -28,7 +28,7 @@
 #define SCRYPT_TEST_HASH_LEN 257 /* (2 * largest block size) + 1 */
 
 static int
-scrypt_test_hash() {
+scrypt_test_hash(void) {
 	scrypt_hash_state st;
 	scrypt_hash_digest hash, final;
 	uint8_t msg[SCRYPT_TEST_HASH_LEN];

--- a/code/scrypt-jane-portable.h
+++ b/code/scrypt-jane-portable.h
@@ -247,7 +247,7 @@ scrypt_verify(const uint8_t *x, const uint8_t *y, size_t len) {
 	return (1 & ((differentbits - 1) >> 8));
 }
 
-void
+static void
 scrypt_ensure_zero(void *p, size_t len) {
 #if ((defined(CPU_X86) || defined(CPU_X86_64)) && defined(COMPILER_MSVC))
 		__stosb((unsigned char *)p, 0, len);

--- a/code/scrypt-jane-portable.h
+++ b/code/scrypt-jane-portable.h
@@ -65,6 +65,8 @@
 	#define ROTR64(a,b) _rotr64(a,b)
 	#undef NOINLINE
 	#define NOINLINE __declspec(noinline)
+	#undef NORETURN
+	#define NORETURN
 	#undef INLINE
 	#define INLINE __forceinline
 	#undef FASTCALL
@@ -96,6 +98,12 @@
 		#define NOINLINE __attribute__((noinline))
 	#else
 		#define NOINLINE
+	#endif
+	#undef NORETURN
+	#if (COMPILER_GCC >= 30000)
+		#define NORETURN __attribute__((noreturn))
+	#else
+		#define NORETURN
 	#endif
 	#undef INLINE
 	#if (COMPILER_GCC >= 30000)

--- a/code/scrypt-jane-romix-basic.h
+++ b/code/scrypt-jane-romix-basic.h
@@ -6,7 +6,7 @@ typedef void (FASTCALL *scrypt_ROMixfn)(scrypt_mix_word_t *X/*[chunkWords]*/, sc
 /* romix pre/post nop function */
 static void asm_calling_convention
 scrypt_romix_nop(scrypt_mix_word_t *blocks, size_t nblocks) {
-  (void)blocks; (void)nblocks;
+	(void)blocks; (void)nblocks;
 }
 
 /* romix pre/post endian conversion function */
@@ -21,6 +21,8 @@ scrypt_romix_convert_endian(scrypt_mix_word_t *blocks, size_t nblocks) {
 			SCRYPT_WORD_ENDIAN_SWAP(blocks[i]);
 		}
 	}
+#else
+	(void)blocks; (void)nblocks;
 #endif
 }
 

--- a/code/scrypt-jane-romix-basic.h
+++ b/code/scrypt-jane-romix-basic.h
@@ -6,6 +6,7 @@ typedef void (FASTCALL *scrypt_ROMixfn)(scrypt_mix_word_t *X/*[chunkWords]*/, sc
 /* romix pre/post nop function */
 static void asm_calling_convention
 scrypt_romix_nop(scrypt_mix_word_t *blocks, size_t nblocks) {
+  (void)blocks; (void)nblocks;
 }
 
 /* romix pre/post endian conversion function */

--- a/code/scrypt-jane-romix-template.h
+++ b/code/scrypt-jane-romix-template.h
@@ -69,7 +69,7 @@ SCRYPT_CHUNKMIX_FN(scrypt_mix_word_t *Bout/*[chunkWords]*/, scrypt_mix_word_t *B
 
 static void NOINLINE FASTCALL
 SCRYPT_ROMIX_FN(scrypt_mix_word_t *X/*[chunkWords]*/, scrypt_mix_word_t *Y/*[chunkWords]*/, scrypt_mix_word_t *V/*[N * chunkWords]*/, uint32_t N, uint32_t r) {
-	uint32_t i, j, chunkWords = SCRYPT_BLOCK_WORDS * r * 2;
+	uint32_t i, j, chunkWords = (uint32_t)(SCRYPT_BLOCK_WORDS * r * 2);
 	scrypt_mix_word_t *block = V;
 
 	SCRYPT_ROMIX_TANGLE_FN(X, r * 2);

--- a/code/scrypt-jane-romix.h
+++ b/code/scrypt-jane-romix.h
@@ -13,11 +13,11 @@
 	#define SCRYPT_BLOCK_WORDS (SCRYPT_BLOCK_BYTES / sizeof(scrypt_mix_word_t))
 	#if !defined(SCRYPT_CHOOSE_COMPILETIME)
 		static void FASTCALL scrypt_ROMix_error(scrypt_mix_word_t *X/*[chunkWords]*/, scrypt_mix_word_t *Y/*[chunkWords]*/, scrypt_mix_word_t *V/*[chunkWords * N]*/, uint32_t N, uint32_t r) {}
-		static scrypt_ROMixfn scrypt_getROMix() { return scrypt_ROMix_error; }
+		static scrypt_ROMixfn scrypt_getROMix(void) { return scrypt_ROMix_error; }
 	#else
 		static void FASTCALL scrypt_ROMix(scrypt_mix_word_t *X, scrypt_mix_word_t *Y, scrypt_mix_word_t *V, uint32_t N, uint32_t r) {}
 	#endif
-	static int scrypt_test_mix() { return 0; }
+	static int scrypt_test_mix(void) { return 0; }
 	#error must define a mix function!
 #endif
 

--- a/code/scrypt-jane-salsa.h
+++ b/code/scrypt-jane-salsa.h
@@ -41,7 +41,7 @@ typedef uint32_t scrypt_mix_word_t;
 
 #if !defined(SCRYPT_CHOOSE_COMPILETIME)
 static scrypt_ROMixfn
-scrypt_getROMix() {
+scrypt_getROMix(void) {
 	size_t cpuflags = detect_cpu();
 
 #if defined(SCRYPT_SALSA_AVX)
@@ -63,7 +63,7 @@ scrypt_getROMix() {
 
 #if defined(SCRYPT_TEST_SPEED)
 static size_t
-available_implementations() {
+available_implementations(void) {
 	size_t cpuflags = detect_cpu();
 	size_t flags = 0;
 
@@ -83,7 +83,7 @@ available_implementations() {
 
 
 static int
-scrypt_test_mix() {
+scrypt_test_mix(void) {
 	static const uint8_t expected[16] = {
 		0x41,0x1f,0x2e,0xa3,0xab,0xa3,0x1a,0x34,0x87,0x1d,0x8a,0x1c,0x76,0xa0,0x27,0x66,
 	};

--- a/code/scrypt-jane-salsa64.h
+++ b/code/scrypt-jane-salsa64.h
@@ -49,7 +49,7 @@ typedef uint64_t scrypt_mix_word_t;
 
 #if !defined(SCRYPT_CHOOSE_COMPILETIME)
 static scrypt_ROMixfn
-scrypt_getROMix() {
+scrypt_getROMix(void) {
 	size_t cpuflags = detect_cpu();
 
 #if defined(SCRYPT_SALSA64_AVX)
@@ -77,7 +77,7 @@ scrypt_getROMix() {
 
 #if defined(SCRYPT_TEST_SPEED)
 static size_t
-available_implementations() {
+available_implementations(void) {
 	size_t cpuflags = detect_cpu();
 	size_t flags = 0;
 
@@ -101,7 +101,7 @@ available_implementations() {
 #endif
 
 static int
-scrypt_test_mix() {
+scrypt_test_mix(void) {
 	static const uint8_t expected[16] = {
 		0xf8,0x92,0x9b,0xf8,0xcc,0x1d,0xce,0x2e,0x13,0x82,0xac,0x96,0xb2,0x6c,0xee,0x2c,
 	};

--- a/code/scrypt-jane-test-vectors.h
+++ b/code/scrypt-jane-test-vectors.h
@@ -6,7 +6,7 @@ typedef struct scrypt_test_setting_t {
 static const scrypt_test_setting post_settings[] = {
 	{"", "", 3, 0, 0},
 	{"password", "NaCl", 9, 3, 4},
-	{0}
+	{0, 0, 0, 0, 0}
 };
 
 #if defined(SCRYPT_SHA256)

--- a/example.c
+++ b/example.c
@@ -2,7 +2,7 @@
 #include "scrypt-jane.h"
 
 
-int main() {
+int main(void) {
 	unsigned char digest[16];
 	int i;
 	scrypt("pw", 2, "salt", 4, 0, 0, 0, digest, 16);

--- a/scrypt-jane-speed.c
+++ b/scrypt-jane-speed.c
@@ -63,7 +63,7 @@ static const scrypt_speed_settings settings[] = {
 	{0}
 };
 
-int main() {
+int main(void) {
 	const scrypt_speed_settings *s;
 	uint8_t password[64], salt[24], digest[64];
 	uint64_t minticks, ticks;

--- a/scrypt-jane-test.c
+++ b/scrypt-jane-test.c
@@ -1,7 +1,7 @@
 #define SCRYPT_TEST
 #include "scrypt-jane.c"
 
-int main() {
+int main(void) {
 	int res = scrypt_power_on_self_test();
 
 	printf("%s: test %s\n", SCRYPT_MIX, (res & 1) ? "ok" : "FAILED");

--- a/scrypt-jane.c
+++ b/scrypt-jane.c
@@ -38,7 +38,7 @@ scrypt_fatal_error_default(const char *msg) {
 static scrypt_fatal_errorfn scrypt_fatal_error = scrypt_fatal_error_default;
 
 void
-scrypt_set_fatal_error_default(scrypt_fatal_errorfn fn) {
+scrypt_set_fatal_error(scrypt_fatal_errorfn fn) {
 	scrypt_fatal_error = fn;
 }
 

--- a/scrypt-jane.c
+++ b/scrypt-jane.c
@@ -27,7 +27,7 @@
 #define scrypt_maxp 25  /* (1 << 25) = ~33 million */
 
 #include <stdio.h>
-#include <malloc.h>
+//#include <malloc.h>
 
 static void
 scrypt_fatal_error_default(const char *msg) {

--- a/scrypt-jane.c
+++ b/scrypt-jane.c
@@ -29,7 +29,7 @@
 #include <stdio.h>
 //#include <malloc.h>
 
-static void
+static void NORETURN
 scrypt_fatal_error_default(const char *msg) {
 	fprintf(stderr, "%s\n", msg);
 	exit(1);

--- a/scrypt-jane.c
+++ b/scrypt-jane.c
@@ -43,7 +43,7 @@ scrypt_set_fatal_error(scrypt_fatal_errorfn fn) {
 }
 
 static int
-scrypt_power_on_self_test() {
+scrypt_power_on_self_test(void) {
 	const scrypt_test_setting *t;
 	uint8_t test_digest[64];
 	uint32_t i;


### PR DESCRIPTION
Hi!

These are the issues I had to fix to get scrypt-jane to build under Tor's set of compiler warnings.

In a couple of cases, you might want an alternative approach instead:

Instead of 6bfcf80, you may want to add a prototype for scrypt_ensure_zero.

Instead of 9bdcf60, you might want to change the name in the header rather than the name of the function.
