### PR TITLE
Define dummy detect_cpu on non x86 platform

### DIFF
--- a/code/scrypt-jane-portable-x86.h
+++ b/code/scrypt-jane-portable-x86.h
@@ -459,4 +459,11 @@ get_top_cpuflag_desc(size_t flag) {
 	#endif
 #endif
 
+#else
+
+static size_t
+detect_cpu(void) {
+	return 0;
+}
+
 #endif /* defined(CPU_X86) || defined(CPU_X86_64) */


### PR DESCRIPTION
e.g. iOS ARM. Fixes compile errors.

@ryancdotorg requested that I PR this.
probably fixes #12.